### PR TITLE
Change versions to deploy on staging

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy --minify",
     "deploy:staging": "wrangler deploy --minify --config wrangler.staging.jsonc",
-    "deploy:version": "wrangler versions upload --minify",
+    "deploy:version": "wrangler versions upload --minify --config wrangler.staging.jsonc",
     "cf-typegen": "wrangler types --env-interface CloudflareBindings"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "start": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "deploy:staging": "opennextjs-cloudflare build && opennextjs-cloudflare deploy --config wrangler.staging.jsonc",
-    "deploy:version": "opennextjs-cloudflare build && npx wrangler versions upload",
+    "deploy:version": "opennextjs-cloudflare build && npx wrangler versions upload --config wrangler.staging.jsonc",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",
     "check-types": "tsc --noEmit",
     "e2e": "npx playwright test",


### PR DESCRIPTION
The versions use the same bindings etc as the main app, so lets deploy them ons taging, as some of them may have durable objects etc